### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -31,10 +31,10 @@ displayShiftOn	KEYWORD2
 displayShiftOff	KEYWORD2
 createCharacter	KEYWORD2
 backlightOn	KEYWORD2
-backlightOff KEYWORD2
+backlightOff	KEYWORD2
 setBrightness	KEYWORD2
 fadeOff	KEYWORD2
-fadeOnce KEYWORD2
+fadeOnce	KEYWORD2
 fadeBlink	KEYWORD2
 ###########################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords